### PR TITLE
Add a method to create a collection of multiple WatchedResource's

### DIFF
--- a/src/Inotify/WatchedResourceCollection.php
+++ b/src/Inotify/WatchedResourceCollection.php
@@ -17,4 +17,18 @@ class WatchedResourceCollection extends TypedCollection
     ): self {
         return (new self())->push(new WatchedResource($pathname, $watchOnChangeFlags, $customName));
     }
+
+    public static function createMultiple(
+        array $paths,
+        int $watchOnChangeFlags,
+        string $customName
+    ): self {
+        $collection = new self();
+
+        foreach ($paths as $pathname) {
+            $collection->push(new WatchedResource($pathname, $watchOnChangeFlags, $customName));
+        }
+
+        return $collection;
+    }
 }


### PR DESCRIPTION
I'm trying to watch multiple folders, like so:

```php
        $foldersToWatch = [self::SOURCE_FOLDER];
        
        $finder = new Finder();
        $finder->in(self::SOURCE_FOLDER)->directories();
        
        foreach ($finder as $directory) {
            $foldersToWatch[] = $directory->getPathname();
        }

        $collection = WatchedResourceCollection::createMultiple(
            $foldersToWatch,
            InotifyEventCodeEnum::ON_MODIFY()->getValue(),
            'fileChanged'
        );

        (new InotifyConsumerFactory())
            ->registerSubscriber(new InotifyModifiedSubscriber($command, $output))
            ->consume($collection);
```

I could loop over the directories myself and push onto the collection after creation, but I thought the `createMultiple` was cleaner :slightly_smiling_face: 