### PR TITLE
Fix make path with file string

### DIFF
--- a/src/Inotify/InotifyEvent.php
+++ b/src/Inotify/InotifyEvent.php
@@ -89,7 +89,7 @@ class InotifyEvent implements Arrayable, JsonSerializable
             return $path;
         }
 
-        if ($this->getFileName()[0] === DIRECTORY_SEPARATOR) {
+        if ($this->getFileName()[0] !== DIRECTORY_SEPARATOR) {
             return $path . DIRECTORY_SEPARATOR . $this->getFileName();
         }
 


### PR DESCRIPTION
This is the output before the edit:
Array
(
    [id] => 1
    [eventCode] => 512
    [eventDescription] => ON_DELETE - File or directory deleted in watched directory
    [uniqueId] => 0
    [fileName] => 2022-07-27T10-00-00.mp4
    [pathName] => /var/www/storage/cameras/camera_1/records
    [customName] => test
    [pathWithFile] => /var/www/storage/cameras/camera_1/records2022-07-27T10-00-00.mp4
    [timestamp] => 1658923622
)

Here in pathWithFile is the path and file name without a separator. In line 92, the first character in the file name is checked and if DIRECTORY_SEPARATOR is there, then another one is added, otherwise it is returned without DIRECTORY_SEPARATOR.

Output after fix:
Array
(
    [id] => 1
    [eventCode] => 512
    [eventDescription] => ON_DELETE - File or directory deleted in watched directory
    [uniqueId] => 0
    [fileName] => 2022-07-27T10-00-00.mp4
    [pathName] => /var/www/storage/cameras/camera_1/records
    [customName] => test
    [pathWithFile] => /var/www/storage/cameras/camera_1/records/2022-07-27T10-00-00.mp4
    [timestamp] => 1658923622
)
